### PR TITLE
Decoding plus chars to spaces

### DIFF
--- a/uri-templates.js
+++ b/uri-templates.js
@@ -147,6 +147,9 @@
 			return result;
 		};
 		var guessFunction = function (stringValue, resultObj) {
+			if (prefix === '?' || prefix === '&') {
+				stringValue = stringValue.replace(/\+/g, ' ');
+			}
 			if (prefix) {
 				if (stringValue.substring(0, prefix.length) == prefix) {
 					stringValue = stringValue.substring(prefix.length);


### PR DESCRIPTION
"Space characters are replaced by `+'..." as per [HTML 4.01 Spec](https://www.w3.org/TR/html401/interact/forms.html#h-17.13.4.1).