### PR TITLE
Fix for notReallyPercentEncode

### DIFF
--- a/uri-templates.js
+++ b/uri-templates.js
@@ -21,7 +21,7 @@
 	};
 
 	function notReallyPercentEncode(string) {
-		return encodeURI(string).replace(/%25[0-9][0-9]/g, function (doubleEncoded) {
+		return encodeURI(string).replace(/%25[0-9][0-9a-fA-F]/g, function (doubleEncoded) {
 			return "%" + doubleEncoded.substring(3);
 		});
 	}


### PR DESCRIPTION
notReallyPercentEncode was ignoring double encoded things that ended with a letter.